### PR TITLE
Add Posit Cloud support for manually specifying appId

### DIFF
--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -583,3 +583,34 @@ test_that("deployDoc() results in correct Cloud API calls", {
     deployStarted = TRUE
   ))
 })
+
+test_that("deployDoc() to manually specified existing content results in correct Cloud API calls", {
+  mock <- deployAppMockServerFactory(expectedAppType="static")
+  mockServer <- mock$server
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  testAccount <- configureTestAccount()
+  withr::defer(removeAccount(testAccount))
+
+  sourcePath = test_path('static-with-quarto-yaml')
+  # Remove local deployment info at end for reproducibility and tidiness.
+  withr::defer(forgetDeployment(appPath=sourcePath))
+
+  deployDoc(
+    paste(sourcePath, "slideshow.html", sep="/"),
+    appId = "lucid:content:1",
+    server = 'posit.cloud',
+    account = testAccount,
+  )
+
+  mock$expect_calls(list(
+    outputCreated = FALSE,
+    revisionCreated = TRUE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+})


### PR DESCRIPTION
So far just a test that fails with the same root cause as if you try passing `appId='lucid:content:xx'` manually.

Will resolve https://github.com/rstudio/rsconnect/issues/819