### PR TITLE
If output is in trashed or archived state, set it to active

### DIFF
--- a/R/client-cloud.R
+++ b/R/client-cloud.R
@@ -86,6 +86,13 @@ cloudClient <- function(service, authInfo) {
         output <- GET(service, authInfo, path)
       }
 
+      # if the output is trashed or archived, restore it to the active state
+      if (output$state == 'trashed' || output$state == 'archived') {
+        json <- list()
+        json$state <- 'active'
+        PATCH_JSON(service, authInfo, paste("/outputs/", output$id, sep = ""), json)
+      }
+
       # Each redeployment of a static output creates a new application. Since
       # those applications can be deleted, it's more reliable to reference
       # outputs by their own id instead of the applications'.

--- a/R/http.R
+++ b/R/http.R
@@ -288,6 +288,43 @@ PUT_JSON <- function(service,
   )
 }
 
+PATCH <- function(service,
+                  authInfo,
+                  path,
+                  query = NULL,
+                  contentType = NULL,
+                  file = NULL,
+                  content = NULL,
+                  headers = list()) {
+  httpRequestWithBody(
+    service,
+    authInfo,
+    "PATCH",
+    path,
+    query,
+    contentType,
+    file,
+    content,
+    headers
+  )
+}
+
+PATCH_JSON <- function(service,
+                       authInfo,
+                       path,
+                       json,
+                       query = NULL,
+                       headers = list()) {
+  PATCH(
+    service,
+    authInfo,
+    path,
+    query,
+    "application/json",
+    content = toJSON(json),
+    headers = headers
+  )
+}
 
 # User options ------------------------------------------------------------
 


### PR DESCRIPTION
This prevents the deployed output from being hidden from the content list in cloud.